### PR TITLE
fix(backup): pin backup pod to node holding RWO PVC

### DIFF
--- a/agent/scripts/lib/backup_context.rhai
+++ b/agent/scripts/lib/backup_context.rhai
@@ -60,7 +60,23 @@ fn run(instance, context, use_init_from) {
         name: "empty-dir",
         mountPath: `/backup`
     }];
-    context["backup_node"] = ();
+    // preferred (not required): co-locates backup with the running app pod, noop when app is scaled to 0.
+    context["pod_affinity"] = #{
+        preferredDuringSchedulingIgnoredDuringExecution: [#{
+            weight: 100,
+            podAffinityTerm: #{
+                labelSelector: #{
+                    matchLabels: context.instance.selector,
+                    matchExpressions: [#{
+                        key: "app.kubernetes.io/component",
+                        operator: "NotIn",
+                        values: ["backup", "restore"]
+                    }]
+                },
+                topologyKey: "kubernetes.io/hostname"
+            }
+        }]
+    };
     context["envs_from"] = [#{
         secretRef: #{
             name: secret_name
@@ -180,24 +196,6 @@ fn run(instance, context, use_init_from) {
                 name: name,
                 mountPath: `/backup/${name}`
             };
-            // Pin backup pod to the node holding the RWO volume to avoid Ceph RBD multi-attach errors.
-            if context["backup_node"] == () {
-                try {
-                    let pvc = k8s_resource("PersistentVolumeClaim", context.instance.namespace).get(v.name);
-                    if pvc.spec.accessModes.contains("ReadWriteOnce") {
-                        let pv_name = pvc.spec.volumeName;
-                        if pv_name != () && pv_name != "" {
-                            let attached = k8s_resource("VolumeAttachment").list().items.filter(|a|
-                                a.spec?.source?.persistentVolumeName == pv_name &&
-                                a.status?.attached == true
-                            );
-                            if attached.len() > 0 {
-                                context["backup_node"] = attached[0].spec.nodeName;
-                            }
-                        }
-                    }
-                } catch {}
-            }
         } else if v.kind == "Secret" {
             if name.is_empty() {
                 name = "secret";

--- a/agent/scripts/lib/backup_context.rhai
+++ b/agent/scripts/lib/backup_context.rhai
@@ -60,6 +60,7 @@ fn run(instance, context, use_init_from) {
         name: "empty-dir",
         mountPath: `/backup`
     }];
+    context["backup_node"] = ();
     context["envs_from"] = [#{
         secretRef: #{
             name: secret_name
@@ -179,6 +180,24 @@ fn run(instance, context, use_init_from) {
                 name: name,
                 mountPath: `/backup/${name}`
             };
+            // Pin backup pod to the node holding the RWO volume to avoid Ceph RBD multi-attach errors.
+            if context["backup_node"] == () {
+                try {
+                    let pvc = k8s_resource("PersistentVolumeClaim", context.instance.namespace).get(v.name);
+                    if pvc.spec.accessModes.contains("ReadWriteOnce") {
+                        let pv_name = pvc.spec.volumeName;
+                        if pv_name != () && pv_name != "" {
+                            let attached = k8s_resource("VolumeAttachment").list().items.filter(|a|
+                                a.spec?.source?.persistentVolumeName == pv_name &&
+                                a.status?.attached == true
+                            );
+                            if attached.len() > 0 {
+                                context["backup_node"] = attached[0].spec.nodeName;
+                            }
+                        }
+                    }
+                } catch {}
+            }
         } else if v.kind == "Secret" {
             if name.is_empty() {
                 name = "secret";

--- a/agent/templates/backup.yaml.hbs
+++ b/agent/templates/backup.yaml.hbs
@@ -39,6 +39,10 @@ spec:
   serviceAccountName: {{service_account}}
   restartPolicy: Never
   priorityClassName: vynil-backup
+  {{#if backup_node}}
+  nodeSelector:
+    kubernetes.io/hostname: {{backup_node}}
+  {{/if}}
   securityContext:
     runAsGroup: 0
     runAsUser: 0

--- a/agent/templates/backup.yaml.hbs
+++ b/agent/templates/backup.yaml.hbs
@@ -39,10 +39,8 @@ spec:
   serviceAccountName: {{service_account}}
   restartPolicy: Never
   priorityClassName: vynil-backup
-  {{#if backup_node}}
-  nodeSelector:
-    kubernetes.io/hostname: {{backup_node}}
-  {{/if}}
+  affinity:
+    podAffinity: {{json_to_str pod_affinity}}
   securityContext:
     runAsGroup: 0
     runAsUser: 0


### PR DESCRIPTION
## Problem

When a package uses a ReadWriteOnce PVC (e.g. Ceph RBD block storage), the Kubernetes
scheduler places the backup pod on an arbitrary node. The kubelet then fails to mount the
volume because Ceph RBD only allows exclusive attachment to a single node at a time:

  Multi-Attach error for volume "pvc-xxx": Volume is already exclusively attached
  to one node and can't be attached to another

The pod ends up stuck in ContainerCreating or Error — the backup never runs.

Note: `maintenance_start.rhai` is currently a TODO (does not scale down the application),
so the application and its RWO PVC remain attached to their node the entire time.

## Root cause

`backup_context.rhai::run()` builds the pod spec with all vital PVCs mounted but adds
no scheduling constraint. The Kubernetes scheduler has no way to know which node already
holds the volume attachment.

## Fix

In `backup_context.rhai::run()`, inject a `preferredDuringSchedulingIgnoredDuringExecution`
podAffinity that targets the instance's running application pods:

```rhai
context["pod_affinity"] = #{
    preferredDuringSchedulingIgnoredDuringExecution: [#{
        weight: 100,
        podAffinityTerm: #{
            labelSelector: #{
                matchLabels: context.instance.selector,
                matchExpressions: [#{
                    key: "app.kubernetes.io/component",
                    operator: "NotIn",
                    values: ["backup", "restore"]
                }]
            },
            topologyKey: "kubernetes.io/hostname"
        }
    }]
};
