### PR TITLE
fix(status): correct PostApplied condition type in set_status_posts and set_status_post_failed

### DIFF
--- a/common/src/instance_macros.rs
+++ b/common/src/instance_macros.rs
@@ -1186,8 +1186,8 @@ macro_rules! impl_instance_befores {
                 let client = $crate::context::get_client_async().await;
                 let generation = self.metadata.generation.unwrap_or(1);
                 let mut conditions: Vec<ApplicationCondition> =
-                    self.get_conditions_excluding(vec![ConditionsType::OtherApplied]);
-                conditions.push(ApplicationCondition::other_ok(generation));
+                    self.get_conditions_excluding(vec![ConditionsType::PostApplied]);
+                conditions.push(ApplicationCondition::post_ok(generation));
                 let result = self
                     .patch_status(
                         client.clone(),
@@ -1213,7 +1213,7 @@ macro_rules! impl_instance_befores {
                 let generation = self.metadata.generation.unwrap_or(1);
                 let mut conditions: Vec<ApplicationCondition> = self.get_conditions_excluding(vec![
                     ConditionsType::AgentStarted,
-                    ConditionsType::OtherApplied,
+                    ConditionsType::PostApplied,
                     ConditionsType::Installed,
                 ]);
                 conditions.push(ApplicationCondition::post_ko(&reason, generation));


### PR DESCRIPTION
## Summary

- `set_status_posts` was excluding `OtherApplied` and pushing `other_ok` instead of using `PostApplied`/`post_ok`, leaving any previous `PostApplied=False` condition untouched after a successful posts step
- `set_status_post_failed` had the same wrong exclusion (`OtherApplied` instead of `PostApplied`), so the failure handler was clearing the wrong condition type
- `set_status_ready` does not exclude `PostApplied`, so the stale `False` condition survived every subsequent successful install

Fixes #199

## Test plan

- [ ] Install a package with a `posts/` directory, make the posts step fail
- [ ] Reinstall successfully — verify `kubectl get vti` shows no errors in the `errors` column and `stage` = `Installed`
- [ ] All existing unit tests pass (`cargo test`)