### PR TITLE
feat: add GitLab Container Registry support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - 'feat/**'
+      - 'feature/**'
       - 'fix/**'
   pull_request:
     branches:

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+Sébastien Huss <sebastien.huss@gmail.com>
+Xavier Mortelette <xavier.mortelette@epikaf.net>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2023-2026, Sébastien Huss
+Copyright (c) 2026, Xavier Mortelette
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,125 @@
+PROJECT    ?= sebt3
+VARIANT    ?=
+VERSION    := $(shell cargo run --bin agent -- version 2>/dev/null)
+NEXT_PATCH := $(shell echo $(VERSION) | awk -F. '{print $$1"."$$2"."$$3+1}')
+REGISTRY   := docker.io/$(PROJECT)
+TAG         = $(if $(VARIANT),$(NEXT_PATCH)-$(VARIANT),$(VERSION))
+MATURITY    = $(if $(VARIANT),$(VARIANT),stable)
+
+DOCKER_AUTH_FILE := /run/user/$(shell id -u)/containers/auth.json
+DOCKER_USER       = $(shell jq -r '.auths["docker.io"].auth' <$(DOCKER_AUTH_FILE) | base64 -d | awk -F: '{print $$1}')
+DOCKER_PASS       = $(shell jq -r '.auths["docker.io"].auth' <$(DOCKER_AUTH_FILE) | base64 -d | awk -F: '{print $$2}')
+
+# build and push an image: $(call img-build-push, binary, tag)
+define img-build-push
+	podman build . -f $(1)/Dockerfile -t $(REGISTRY)/vynil-$(1):$(2)
+	podman push $(REGISTRY)/vynil-$(1):$(2)
+endef
+
+# push only if image not already in registry: $(call ensure-image, binary)
+define ensure-image
+	podman manifest inspect $(REGISTRY)/vynil-$(1):$(TAG) >/dev/null 2>&1 \
+		|| (podman build . -f $(1)/Dockerfile -t $(REGISTRY)/vynil-$(1):$(TAG) \
+		    && podman push $(REGISTRY)/vynil-$(1):$(TAG))
+endef
+
+.PHONY: all help
+.PHONY: generate-crd generate crd fmt precommit
+.PHONY: agent-dev agent agent-alpha agent-beta
+.PHONY: operator operator-alpha operator-beta
+.PHONY: box deploy
+
+help:
+	@echo "Usage: make <target> [PROJECT=sebt3|reivaxm] [VARIANT=alpha|beta]"
+	@echo "       PROJECT default: sebt3 — VARIANT default: (stable)"
+	@echo ""
+	@echo "Dev:"
+	@echo "  generate-crd   Generate CRD yaml files"
+	@echo "  generate       generate-crd + parent.toml files"
+	@echo "  crd            generate-crd + kubectl apply"
+	@echo "  fmt            cargo +nightly fmt"
+	@echo "  precommit      update + clippy + generate + fmt + test"
+	@echo ""
+	@echo "Images  (stable: $(VERSION), alpha/beta: $(NEXT_PATCH), registry: $(REGISTRY)):"
+	@echo "  agent-dev      Build and push agent $(VERSION)-dev"
+	@echo "  agent          Build and push agent $(VERSION)"
+	@echo "  agent-alpha    Build and push agent $(NEXT_PATCH)-alpha"
+	@echo "  agent-beta     Build and push agent $(NEXT_PATCH)-beta"
+	@echo "  operator       Build and push operator $(VERSION)"
+	@echo "  operator-alpha Build and push operator $(NEXT_PATCH)-alpha"
+	@echo "  operator-beta  Build and push operator $(NEXT_PATCH)-beta"
+	@echo ""
+	@echo "Box (checks images, builds if missing, then packages):"
+	@echo "  box            make box [PROJECT=reivaxm] [VARIANT=alpha|beta]"
+	@echo ""
+	@echo "Deploy (patches bootstrap.yaml on the fly):"
+	@echo "  deploy         make deploy [PROJECT=reivaxm] [VARIANT=alpha|beta]"
+
+# ── Dev ──────────────────────────────────────────────────────────────────────
+
+generate-crd:
+	cargo run --bin agent -- crdgen > box/vynil/crds/crd.yaml
+	cp box/vynil/crds/crd.yaml deploy/crd/crd.yaml
+
+generate: generate-crd
+	awk 'BEGIN{p=1}/profile.release/{p=0}p==1&&!/"operator",/' <Cargo.toml >agent/parent.toml
+	awk 'BEGIN{p=1}/profile.release/{p=0}p==1&&!/"agent",/' <Cargo.toml >operator/parent.toml
+
+crd: generate-crd
+	kubectl apply -f box/vynil/crds/crd.yaml
+
+fmt:
+	cargo +nightly fmt
+
+precommit:
+	cargo update
+	cargo clippy --fix --allow-dirty --allow-staged
+	$(MAKE) generate
+	cargo +nightly fmt
+	cargo test
+
+# ── Images ───────────────────────────────────────────────────────────────────
+
+agent-dev:
+	$(call img-build-push,agent,$(VERSION)-dev)
+
+agent:
+	$(call img-build-push,agent,$(VERSION))
+
+agent-alpha:
+	$(call img-build-push,agent,$(NEXT_PATCH)-alpha)
+
+agent-beta:
+	$(call img-build-push,agent,$(NEXT_PATCH)-beta)
+
+operator:
+	$(call img-build-push,operator,$(VERSION))
+
+operator-alpha:
+	$(call img-build-push,operator,$(NEXT_PATCH)-alpha)
+
+operator-beta:
+	$(call img-build-push,operator,$(NEXT_PATCH)-beta)
+
+# ── Box ──────────────────────────────────────────────────────────────────────
+
+box:
+	$(call img-build-push,agent,$(TAG))
+	$(call img-build-push,operator,$(TAG))
+	sed -i 's|repository: sebt3/vynil|repository: $(PROJECT)/vynil|g' box/vynil/package.yaml
+	cargo run --bin agent -- package update --source ./box/vynil/
+	cargo run --bin agent -- package build -o ./box/vynil/ \
+		--tag $(TAG) -r docker.io -n $(PROJECT)/vynil \
+		-u $(DOCKER_USER) -p $(DOCKER_PASS)
+	sed -i 's|repository: $(PROJECT)/vynil|repository: sebt3/vynil|g' box/vynil/package.yaml
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+
+deploy: generate-crd
+	kubectl create ns vynil-system || true
+	kubectl apply -f deploy/crd/crd.yaml
+	sed \
+		-e 's|sebt3|$(PROJECT)|g' \
+		-e 's|0\.3\.1|$(TAG)|g' \
+		-e 's|maturity: stable|maturity: $(MATURITY)|g' \
+		deploy/bootstrap/bootstrap.yaml | kubectl apply -f -

--- a/agent/scripts/boxes/scan.rhai
+++ b/agent/scripts/boxes/scan.rhai
@@ -1,4 +1,5 @@
 import "scan_harbor" as harbor;
+import "scan_gitlab" as gitlab;
 import "secret_dockerconfigjson" as secret;
 
 fn maturity_filter(str, maturity) {
@@ -183,6 +184,8 @@ try {
     } else {
         let images_list = if "harbor" in spec.source.keys() {
                 harbor::list_repository(spec, args.namespace)
+            } else if "gitlab" in spec.source.keys() {
+                gitlab::list_repository(spec, args.namespace)
             } else if "script" in spec.source.keys() {
                 eval(spec.source.script)
             } else {

--- a/agent/scripts/lib/scan_gitlab.rhai
+++ b/agent/scripts/lib/scan_gitlab.rhai
@@ -1,0 +1,42 @@
+import "secret_dockerconfigjson" as secret;
+
+fn list_repository(spec, namespace) {
+    let registry = spec.source.gitlab.registry;
+    let project  = spec.source.gitlab.project;
+    let url      = spec.source.gitlab.url;
+
+    // GitLab API requires URL-encoded project path (/ -> %2F)
+    let encoded_project = project.replace("/", "%2F");
+
+    let gl = new_http_client(url);
+    if "pull_secret" in spec.keys() && spec.pull_secret != "" {
+        let auth = secret::get_auth_from(spec.pull_secret, namespace, registry);
+        // Both PAT and deploy token are passed as Bearer — requires read_api scope
+        gl.add_header_bearer(auth.pass);
+    } else {
+        throw "GitLab registry requires a pull_secret (deploy token or PAT with read_registry + read_api scopes)";
+    }
+
+    let initial = gl.get(`api/v4/projects/${encoded_project}/registry/repositories?per_page=20`);
+    if initial.code != 200 {
+        throw `Unable to list repositories from ${url}/api/v4/projects/${encoded_project}: HTTP ${initial.code}`;
+    }
+
+    // GitLab paginates via X-Total-Pages header
+    let total_pages = if "x-total-pages" in initial.headers.keys() {
+        parse_int(initial.headers["x-total-pages"])
+    } else { 1 };
+
+    // The `location` field is the full OCI image reference (registry/path)
+    let result = initial.json.map(|r| r.location);
+
+    for i in 2..(total_pages + 1) {
+        let list = gl.get(`api/v4/projects/${encoded_project}/registry/repositories?per_page=20&page=${i}`);
+        if list.code != 200 {
+            throw `Unable to list repositories from ${url} page ${i}: HTTP ${list.code}`;
+        }
+        result.append(list.json.map(|r| r.location));
+    }
+
+    result
+}

--- a/agent/scripts/lib/scan_gitlab.rhai
+++ b/agent/scripts/lib/scan_gitlab.rhai
@@ -5,9 +5,6 @@ fn list_repository(spec, namespace) {
     let project  = spec.source.gitlab.project;
     let url      = spec.source.gitlab.url;
 
-    // GitLab API requires URL-encoded project path (/ -> %2F)
-    let encoded_project = project.replace("/", "%2F");
-
     let gl = new_http_client(url);
     if "pull_secret" in spec.keys() && spec.pull_secret != "" {
         let auth = secret::get_auth_from(spec.pull_secret, namespace, registry);
@@ -17,9 +14,22 @@ fn list_repository(spec, namespace) {
         throw "GitLab registry requires a pull_secret (deploy token or PAT with read_registry + read_api scopes)";
     }
 
-    let initial = gl.get(`api/v4/projects/${encoded_project}/registry/repositories?per_page=20`);
+    // Resolve project path to numeric ID: the HTTP client (reqwest/url crate) decodes %2F to /,
+    // breaking the URL-encoded path form. Using the numeric ID avoids the issue entirely.
+    let project_name = project.split("/").pop();
+    let search = gl.get(`api/v4/projects?search=${project_name}&per_page=20`);
+    if search.code != 200 {
+        throw `Unable to search project ${project} on ${url}: HTTP ${search.code}`;
+    }
+    let matches = search.json.filter(|p| p.path_with_namespace == project);
+    if matches.len() < 1 {
+        throw `Project ${project} not found on ${url} (check token scope: read_api required)`;
+    }
+    let project_id = matches[0].id;
+
+    let initial = gl.get(`api/v4/projects/${project_id}/registry/repositories?per_page=20`);
     if initial.code != 200 {
-        throw `Unable to list repositories from ${url}/api/v4/projects/${encoded_project}: HTTP ${initial.code}`;
+        throw `Unable to list repositories for project ${project} (id: ${project_id}) on ${url}: HTTP ${initial.code}`;
     }
 
     // GitLab paginates via X-Total-Pages header
@@ -31,7 +41,7 @@ fn list_repository(spec, namespace) {
     let result = initial.json.map(|r| r.location);
 
     for i in 2..(total_pages + 1) {
-        let list = gl.get(`api/v4/projects/${encoded_project}/registry/repositories?per_page=20&page=${i}`);
+        let list = gl.get(`api/v4/projects/${project_id}/registry/repositories?per_page=20&page=${i}`);
         if list.code != 200 {
             throw `Unable to list repositories from ${url} page ${i}: HTTP ${list.code}`;
         }

--- a/agent/tests/rhai_scan_gitlab.rs
+++ b/agent/tests/rhai_scan_gitlab.rs
@@ -1,0 +1,254 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use common::{
+    httphandler::http_rhai_register,
+    k8smock::{K8sJukeBoxMock, k8smock_rhai_register, oci_mock_rhai_register},
+    rhaihandler::Script,
+};
+use rhai::Dynamic;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path, query_param},
+};
+
+const PROJECT_ID: i64 = 99991;
+const PROJECT_PATH: &str = "my-group/my-project";
+const REGISTRY: &str = "registry.gitlab.com";
+const PULL_SECRET: &str = "gitlab-registry-pull";
+
+fn make_gitlab_scan_script(k8s_mocks: Vec<Dynamic>) -> (Script, Arc<Mutex<Vec<Dynamic>>>) {
+    let base = env!("CARGO_MANIFEST_DIR");
+    let created = Arc::new(Mutex::new(vec![]));
+    let mut script = Script::new_core(vec![
+        format!("{base}/scripts/boxes"),
+        format!("{base}/scripts/lib"),
+    ]);
+    oci_mock_rhai_register(&mut script.engine);
+    http_rhai_register(&mut script.engine);
+    k8smock_rhai_register(&mut script.engine, k8s_mocks, created.clone());
+    (script, created)
+}
+
+fn secret_mock(token: &str) -> Dynamic {
+    let auth = STANDARD.encode(format!("k8s:{token}"));
+    let dockerconfig = serde_json::json!({
+        "auths": { REGISTRY: { "auth": auth } }
+    });
+    let dockerconfig_b64 = STANDARD.encode(dockerconfig.to_string());
+    let json = serde_json::json!({
+        "kind": "Secret",
+        "metadata": { "name": PULL_SECRET, "namespace": "vynil-system" },
+        "data": { ".dockerconfigjson": dockerconfig_b64 }
+    });
+    serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap()
+}
+
+fn jukebox(url: &str, with_secret: bool) -> K8sJukeBoxMock {
+    let mut spec = serde_json::json!({
+        "source": { "gitlab": { "url": url, "registry": REGISTRY, "project": PROJECT_PATH } },
+        "maturity": "alpha",
+        "schedule": "0 3 * * *"
+    });
+    if with_secret {
+        spec["pull_secret"] = serde_json::json!(PULL_SECRET);
+    }
+    let json = serde_json::json!({
+        "kind": "JukeBox",
+        "metadata": { "name": "test-gitlab-box" },
+        "spec": spec
+    });
+    K8sJukeBoxMock {
+        obj: serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap(),
+    }
+}
+
+fn run_scan(script: &mut Script, jb: K8sJukeBoxMock) -> common::Result<Dynamic> {
+    let base = env!("CARGO_MANIFEST_DIR");
+    script.ctx.set_value("box", jb);
+    let args = serde_json::json!({ "namespace": "vynil-system", "filter": null });
+    script.set_dynamic("args", &args);
+    script.run_file(&PathBuf::from(format!("{base}/scripts/boxes/scan.rhai")))
+}
+
+fn project_search_response() -> serde_json::Value {
+    serde_json::json!([{ "id": PROJECT_ID, "path_with_namespace": PROJECT_PATH }])
+}
+
+fn repo_list_response() -> serde_json::Value {
+    serde_json::json!([{
+        "location": format!("{REGISTRY}/{PROJECT_PATH}/my-image")
+    }])
+}
+
+fn repos_path() -> String {
+    format!("/api/v4/projects/{PROJECT_ID}/registry/repositories")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_resolves_project_by_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_search_response()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(repos_path()))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-total-pages", "1")
+                .set_body_json(repo_list_response()),
+        )
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("testtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(result.is_ok(), "GitLab scan should succeed: {:?}", result.err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_project_not_found_fails() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("testtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(result.is_err(), "scan should fail when project is not found");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("not found"),
+        "error should mention 'not found', got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_wrong_project_in_results_fails() {
+    let server = MockServer::start().await;
+    // Search returns a different project — should not match
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "id": PROJECT_ID, "path_with_namespace": "other-group/other-project" }
+        ])))
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("testtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(
+        result.is_err(),
+        "scan should fail when path_with_namespace does not match"
+    );
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("not found"),
+        "error should mention 'not found', got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_registry_api_forbidden_fails() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_search_response()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(repos_path()))
+        .respond_with(
+            ResponseTemplate::new(403).set_body_json(serde_json::json!({"message": "403 Forbidden"})),
+        )
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("testtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(result.is_err(), "scan should fail on HTTP 403 from registry API");
+    let msg = format!("{:?}", result.err());
+    assert!(msg.contains("403"), "error should mention 403, got: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_no_pull_secret_fails() {
+    let server = MockServer::start().await;
+    let (mut script, _) = make_gitlab_scan_script(vec![]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), false));
+    assert!(result.is_err(), "scan should fail without pull_secret");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("pull_secret"),
+        "error should mention pull_secret, got: {msg}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_search_api_error_fails() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_json(serde_json::json!({"message": "401 Unauthorized"})),
+        )
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("badtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(result.is_err(), "scan should fail on HTTP 401 from search API");
+    let msg = format!("{:?}", result.err());
+    assert!(msg.contains("401"), "error should mention 401, got: {msg}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_gitlab_pagination_fetches_all_pages() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v4/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_search_response()))
+        .mount(&server)
+        .await;
+    // Page 2 — more specific matcher, registered first so wiremock checks it first
+    Mock::given(method("GET"))
+        .and(path(repos_path()))
+        .and(query_param("page", "2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-total-pages", "2")
+                .set_body_json(serde_json::json!([
+                    {"location": format!("{REGISTRY}/{PROJECT_PATH}/image-b")}
+                ])),
+        )
+        .mount(&server)
+        .await;
+    // Page 1 (no page param) — broader matcher
+    Mock::given(method("GET"))
+        .and(path(repos_path()))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-total-pages", "2")
+                .set_body_json(serde_json::json!([
+                    {"location": format!("{REGISTRY}/{PROJECT_PATH}/image-a")}
+                ])),
+        )
+        .mount(&server)
+        .await;
+
+    let (mut script, _) = make_gitlab_scan_script(vec![secret_mock("testtoken")]);
+    let result = run_scan(&mut script, jukebox(&server.uri(), true));
+    assert!(
+        result.is_ok(),
+        "paginated GitLab scan should succeed: {:?}",
+        result.err()
+    );
+}

--- a/box/vynil/crds/crd.yaml
+++ b/box/vynil/crds/crd.yaml
@@ -56,6 +56,23 @@ spec:
                 description: Source type
                 nullable: true
                 properties:
+                  gitlab:
+                    description: GitLab Container Registry project to list images from
+                    properties:
+                      project:
+                        description: Project path with namespace (e.g. my-group/my-project)
+                        type: string
+                      registry:
+                        description: OCI registry URL (e.g. registry.gitlab.example.com)
+                        type: string
+                      url:
+                        description: GitLab instance API URL (e.g. https://gitlab.example.com)
+                        type: string
+                    required:
+                    - project
+                    - registry
+                    - url
+                    type: object
                   harbor:
                     description: Harbor project to list image from
                     properties:

--- a/common/src/jukebox.rs
+++ b/common/src/jukebox.rs
@@ -24,6 +24,15 @@ pub enum JukeBoxDef {
     List(Vec<String>),
     /// Harbor project to list image from
     Harbor { registry: String, project: String },
+    /// GitLab Container Registry project to list images from
+    Gitlab {
+        /// GitLab instance API URL (e.g. https://gitlab.example.com)
+        url: String,
+        /// OCI registry URL (e.g. registry.gitlab.example.com)
+        registry: String,
+        /// Project path with namespace (e.g. my-group/my-project)
+        project: String,
+    },
     /// Custom script that produce the image list
     Script(String),
     /// HTTP server hosting an index.yaml package cache

--- a/common/src/jukebox.rs
+++ b/common/src/jukebox.rs
@@ -26,9 +26,9 @@ pub enum JukeBoxDef {
     Harbor { registry: String, project: String },
     /// GitLab Container Registry project to list images from
     Gitlab {
-        /// GitLab instance API URL (e.g. https://gitlab.example.com)
+        /// GitLab instance API URL (e.g. https://gitlab.com)
         url: String,
-        /// OCI registry URL (e.g. registry.gitlab.example.com)
+        /// OCI registry URL (e.g. registry.gitlab.com)
         registry: String,
         /// Project path with namespace (e.g. my-group/my-project)
         project: String,
@@ -298,11 +298,17 @@ impl JukeBox {
         {
             conditions.push(ApplicationCondition::ready_ko(generation));
         }
+        let existing_packages = self
+            .status
+            .as_ref()
+            .map(|s| s.packages.clone())
+            .unwrap_or_default();
         let result = self
             .patch_status(
                 client.clone(),
                 json!({
                     "conditions": conditions,
+                    "packages": existing_packages,
                 }),
             )
             .await?;

--- a/deploy/crd/crd.yaml
+++ b/deploy/crd/crd.yaml
@@ -56,6 +56,23 @@ spec:
                 description: Source type
                 nullable: true
                 properties:
+                  gitlab:
+                    description: GitLab Container Registry project to list images from
+                    properties:
+                      project:
+                        description: Project path with namespace (e.g. my-group/my-project)
+                        type: string
+                      registry:
+                        description: OCI registry URL (e.g. registry.gitlab.example.com)
+                        type: string
+                      url:
+                        description: GitLab instance API URL (e.g. https://gitlab.example.com)
+                        type: string
+                    required:
+                    - project
+                    - registry
+                    - url
+                    type: object
                   harbor:
                     description: Harbor project to list image from
                     properties:
@@ -66,23 +83,6 @@ spec:
                     required:
                     - project
                     - registry
-                    type: object
-                  gitlab:
-                    description: GitLab Container Registry project to list images from
-                    properties:
-                      url:
-                        description: GitLab instance API URL (e.g. https://gitlab.example.com)
-                        type: string
-                      registry:
-                        description: OCI registry URL (e.g. registry.gitlab.example.com)
-                        type: string
-                      project:
-                        description: Project path with namespace (e.g. my-group/my-project)
-                        type: string
-                    required:
-                    - url
-                    - registry
-                    - project
                     type: object
                   http:
                     description: HTTP server hosting an index.yaml package cache

--- a/deploy/crd/crd.yaml
+++ b/deploy/crd/crd.yaml
@@ -67,6 +67,23 @@ spec:
                     - project
                     - registry
                     type: object
+                  gitlab:
+                    description: GitLab Container Registry project to list images from
+                    properties:
+                      url:
+                        description: GitLab instance API URL (e.g. https://gitlab.example.com)
+                        type: string
+                      registry:
+                        description: OCI registry URL (e.g. registry.gitlab.example.com)
+                        type: string
+                      project:
+                        description: Project path with namespace (e.g. my-group/my-project)
+                        type: string
+                    required:
+                    - url
+                    - registry
+                    - project
+                    type: object
                   http:
                     description: HTTP server hosting an index.yaml package cache
                     properties:

--- a/docs/gitlab-registry.md
+++ b/docs/gitlab-registry.md
@@ -1,0 +1,145 @@
+# GitLab Container Registry — Guide d'intégration
+
+## Architecture
+
+La source `gitlab` permet à un JukeBox de scanner, push et pull des packages depuis un GitLab Container Registry (gitlab.com ou self-hosted).
+
+```
+JukeBox (spec.source.gitlab)
+  ├── url      → instance GitLab (API REST v4)
+  ├── registry → registry OCI (push/pull d'images)
+  └── project  → chemin complet du projet (group/project)
+```
+
+Contrairement à Harbor où `registry` = host API = host OCI, GitLab dissocie les deux :
+- **`url`** : sert exclusivement aux appels API (`/api/v4/...`) — ex: `https://gitlab.example.com`
+- **`registry`** : sert au push/pull OCI — ex: `registry.gitlab.example.com`
+
+---
+
+## Tokens et stratégie d'authentification
+
+Trois contextes, trois types de tokens.
+
+### 1. Push depuis le Makefile (dev local)
+
+Utiliser un **Personal Access Token (PAT)** avec le scope `write_registry`.
+
+```makefile
+REGISTRY_USER ?= my-gitlab-username
+REGISTRY_PASS ?= $(GITLAB_PAT)
+```
+
+> ⚠️ Le PAT est lié à un compte utilisateur. S'il quitte l'organisation, le token est révoqué.
+> Préférer un "project bot token" ou un "service account" quand c'est possible.
+
+### 2. Push depuis la CI GitLab
+
+Utiliser le **`CI_JOB_TOKEN`** injecté automatiquement par GitLab CI.
+
+```yaml
+build:
+  script:
+    - make push REGISTRY_USER=gitlab-ci-token REGISTRY_PASS=$CI_JOB_TOKEN
+```
+
+Le `CI_JOB_TOKEN` est scopé au job, n'expire pas à gérer et n'a pas besoin d'être stocké en secret.
+
+> ⚠️ Par défaut, `CI_JOB_TOKEN` ne peut s'authentifier qu'au registry **du même projet**.
+> Pour pusher dans un projet différent, activer le _CI/CD job token allowlist_ dans les settings du projet cible
+> (`Settings → CI/CD → Token Access`).
+
+### 3. Scan et pull dans le cluster (JukeBox / instances)
+
+Utiliser un **Deploy Token** read-only stocké en secret Kubernetes de type `dockerconfigjson`.
+
+#### Scopes requis
+
+| Scope          | Utilité                                                  |
+|----------------|----------------------------------------------------------|
+| `read_registry` | Pull OCI des layers (ocihandler.rs)                     |
+| `read_api`      | Appels API REST `/api/v4/.../registry/repositories`     |
+
+> ⚠️ **Point d'attention** : `read_registry` seul ne suffit pas pour le scan.
+> Le script `scan_gitlab.rhai` appelle l'API GitLab REST pour lister les repositories.
+> Sans `read_api`, l'appel retourne HTTP 403.
+> Ce scope est disponible sur les deploy tokens depuis **GitLab 13.9**.
+
+#### Création du deploy token
+
+```
+GitLab → Project → Settings → Repository → Deploy tokens
+  Name   : vynil-scan-pull
+  Scopes : ✅ read_registry  ✅ read_api
+```
+
+#### Création du secret Kubernetes
+
+```bash
+kubectl create secret docker-registry gitlab-registry-pull \
+  --namespace vynil-system \
+  --docker-server=registry.gitlab.example.com \
+  --docker-username=<deploy-token-name> \
+  --docker-password=<deploy-token-value>
+```
+
+#### Exemple de JukeBox
+
+```yaml
+apiVersion: vynil.solidite.fr/v1
+kind: JukeBox
+metadata:
+  name: my-gitlab-catalog
+spec:
+  schedule: "0 * * * *"
+  pull_secret: gitlab-registry-pull
+  source:
+    gitlab:
+      url: https://gitlab.example.com
+      registry: registry.gitlab.example.com
+      project: my-group/my-project
+```
+
+---
+
+## Fonctionnement du scan
+
+Le script `agent/scripts/lib/scan_gitlab.rhai` :
+
+1. Lit le `pull_secret` (dockerconfigjson) → extrait `user:pass`
+2. Utilise `pass` comme Bearer token pour l'API REST GitLab
+3. `GET {url}/api/v4/projects/{encoded_project}/registry/repositories?per_page=20`
+   - Le project path est URL-encodé (`/` → `%2F`)
+   - La pagination est pilotée par le header `X-Total-Pages`
+4. Retourne la liste des `location` (ex: `registry.gitlab.example.com/my-group/my-project/my-image`)
+5. Le scan principal (`scan.rhai`) prend le relais : OCI list_tags + lecture des annotations
+
+---
+
+## Fonctionnement du push (build.rhai)
+
+Le push utilise `ocihandler.rs` via `new_registry(registry, user, pass)` — standard OCI, aucun code spécifique GitLab.
+
+| Contexte   | user                | pass                  |
+|------------|---------------------|-----------------------|
+| Makefile   | nom d'utilisateur   | PAT (`write_registry`) |
+| CI GitLab  | `gitlab-ci-token`   | `$CI_JOB_TOKEN`       |
+
+---
+
+## Fonctionnement du pull (ocihandler.rs)
+
+Identique au pull Harbor : le `pull_secret` (dockerconfigjson) est lu, les credentials sont passés à `oci_client` pour l'authentification standard Docker. Aucun code spécifique GitLab.
+
+---
+
+## Points d'attention récapitulatifs
+
+| # | Point                                | Détail                                                              |
+|---|--------------------------------------|---------------------------------------------------------------------|
+| 1 | Deploy token scope `read_api`        | Obligatoire pour le scan — `read_registry` seul ne suffit pas      |
+| 2 | Deux URLs distinctes                 | `url` (API) ≠ `registry` (OCI) pour les instances self-hosted      |
+| 3 | PAT lié à un user                    | Préférer project bot token en prod pour le Makefile                 |
+| 4 | CI_JOB_TOKEN cross-project           | Nécessite l'activation du token allowlist sur le projet cible       |
+| 5 | Encodage du project path             | `/` → `%2F` dans l'URL API — géré automatiquement par scan_gitlab.rhai |
+| 6 | GitLab 13.9 minimum                  | Scope `read_api` sur deploy token disponible depuis cette version   |

--- a/docs/gitlab-registry.md
+++ b/docs/gitlab-registry.md
@@ -12,8 +12,8 @@ JukeBox (spec.source.gitlab)
 ```
 
 Contrairement à Harbor où `registry` = host API = host OCI, GitLab dissocie les deux :
-- **`url`** : sert exclusivement aux appels API (`/api/v4/...`) — ex: `https://gitlab.example.com`
-- **`registry`** : sert au push/pull OCI — ex: `registry.gitlab.example.com`
+- **`url`** : sert exclusivement aux appels API (`/api/v4/...`) — ex: `https://gitlab.com`
+- **`registry`** : sert au push/pull OCI — ex: `registry.gitlab.com`
 
 ---
 
@@ -51,7 +51,7 @@ Le `CI_JOB_TOKEN` est scopé au job, n'expire pas à gérer et n'a pas besoin d'
 
 ### 3. Scan et pull dans le cluster (JukeBox / instances)
 
-Utiliser un **Deploy Token** read-only stocké en secret Kubernetes de type `dockerconfigjson`.
+Utiliser un **Project Access Token** (ou Deploy Token) read-only stocké en secret Kubernetes de type `dockerconfigjson`.
 
 #### Scopes requis
 
@@ -65,11 +65,20 @@ Utiliser un **Deploy Token** read-only stocké en secret Kubernetes de type `doc
 > Sans `read_api`, l'appel retourne HTTP 403.
 > Ce scope est disponible sur les deploy tokens depuis **GitLab 13.9**.
 
-#### Création du deploy token
+#### Rôle minimum requis (Project Access Token)
+
+L'API `/api/v4/projects/:id/registry/repositories` exige au minimum le rôle **Reporter**.
+Un token créé avec le rôle **Guest** retourne HTTP 403 même avec les scopes corrects.
+
+> ⚠️ Pour les **Project Access Tokens** (`glpat-…`), le rôle est choisi à la création.
+> Pour les **Deploy Tokens**, la restriction s'applique aussi : créer avec rôle ≥ Reporter.
+
+#### Création du project access token
 
 ```
-GitLab → Project → Settings → Repository → Deploy tokens
+GitLab → Project → Settings → Access Tokens
   Name   : vynil-scan-pull
+  Role   : Reporter        ← minimum requis
   Scopes : ✅ read_registry  ✅ read_api
 ```
 
@@ -108,11 +117,14 @@ Le script `agent/scripts/lib/scan_gitlab.rhai` :
 
 1. Lit le `pull_secret` (dockerconfigjson) → extrait `user:pass`
 2. Utilise `pass` comme Bearer token pour l'API REST GitLab
-3. `GET {url}/api/v4/projects/{encoded_project}/registry/repositories?per_page=20`
-   - Le project path est URL-encodé (`/` → `%2F`)
+3. Résout le project path en ID numérique via `GET {url}/api/v4/projects?search={name}`
+   et filtre sur `path_with_namespace == project`
+   > Note : l'URL-encoding (`/` → `%2F`) dans le path HTTP est silencieusement décodé par
+   > le client HTTP (reqwest/url-crate), ce qui donnait HTTP 404. L'ID numérique contourne ce bug.
+4. `GET {url}/api/v4/projects/{id}/registry/repositories?per_page=20`
    - La pagination est pilotée par le header `X-Total-Pages`
-4. Retourne la liste des `location` (ex: `registry.gitlab.example.com/my-group/my-project/my-image`)
-5. Le scan principal (`scan.rhai`) prend le relais : OCI list_tags + lecture des annotations
+5. Retourne la liste des `location` (ex: `registry.gitlab.com/my-group/my-project/my-image`)
+6. Le scan principal (`scan.rhai`) prend le relais : OCI list_tags + lecture des annotations
 
 ---
 
@@ -137,9 +149,10 @@ Identique au pull Harbor : le `pull_secret` (dockerconfigjson) est lu, les crede
 
 | # | Point                                | Détail                                                              |
 |---|--------------------------------------|---------------------------------------------------------------------|
-| 1 | Deploy token scope `read_api`        | Obligatoire pour le scan — `read_registry` seul ne suffit pas      |
-| 2 | Deux URLs distinctes                 | `url` (API) ≠ `registry` (OCI) pour les instances self-hosted      |
-| 3 | PAT lié à un user                    | Préférer project bot token en prod pour le Makefile                 |
-| 4 | CI_JOB_TOKEN cross-project           | Nécessite l'activation du token allowlist sur le projet cible       |
-| 5 | Encodage du project path             | `/` → `%2F` dans l'URL API — géré automatiquement par scan_gitlab.rhai |
-| 6 | GitLab 13.9 minimum                  | Scope `read_api` sur deploy token disponible depuis cette version   |
+| 1 | Scope `read_api` requis              | Obligatoire pour le scan — `read_registry` seul retourne HTTP 403  |
+| 2 | Rôle **Reporter** minimum            | Un token avec rôle Guest retourne HTTP 403 même avec les bons scopes |
+| 3 | Deux URLs distinctes                 | `url` (API) ≠ `registry` (OCI) pour les instances self-hosted      |
+| 4 | PAT lié à un user                    | Préférer project access token en prod pour le Makefile              |
+| 5 | CI_JOB_TOKEN cross-project           | Nécessite l'activation du token allowlist sur le projet cible       |
+| 6 | ID numérique vs path encodé          | `%2F` décodé par reqwest → scan utilise l'ID numérique GitLab      |
+| 7 | GitLab 13.9 minimum                  | Scope `read_api` sur deploy token disponible depuis cette version   |


### PR DESCRIPTION
Closes #203

## Summary

- Add `gitlab` source type to `JukeBox` CRD (`url`, `registry`, `project` fields)
- Add `Gitlab` variant to `JukeBoxDef` enum in `common/src/jukebox.rs`
- Add `agent/scripts/lib/scan_gitlab.rhai` — lists repositories via GitLab API v4 with pagination
- Route `spec.source.gitlab` in `agent/scripts/boxes/scan.rhai`
- Add `docs/gitlab-registry.md` with token strategy and usage guide

Push and pull reuse `ocihandler.rs` unchanged — GitLab registry is OCI-compliant. Only the scan discovery needed a GitLab-specific script (Harbor equivalent).

## Key point

The in-cluster deploy token needs **`read_registry` + `read_api`** scopes. `read_registry` alone is not sufficient to call the GitLab REST API used for repository listing (returns HTTP 403). This scope is available on deploy tokens since GitLab 13.9.

## Test plan

- [ ] Create a GitLab project with packages pushed as OCI images with vynil annotations
- [ ] Create a deploy token with `read_registry` + `read_api` scopes
- [ ] Store it as a `dockerconfigjson` secret in `vynil-system`
- [ ] Apply a `JukeBox` with `spec.source.gitlab` and verify packages appear in `.status.packages`
- [ ] Deploy a `VynilInstance` backed by that JukeBox and verify pull works