### PR TITLE
fix: skip tofu on empty tofu/ dir and sync provider versions with image cache

### DIFF
--- a/agent/scripts/lib/tofu_gen.rhai
+++ b/agent/scripts/lib/tofu_gen.rhai
@@ -2,7 +2,11 @@ import "tofu" as tf;
 fn has_tofu_files(path) {
     if !is_dir(path) { return false; }
     let generated = ["00_vynil_vars.tf", "00_vynil_locals.tf"];
-    read_dir(path).any(|f| glob(basename(f), "*.tf") && !generated.contains(basename(f)))
+    for f in read_dir(path) {
+        let b = basename(f);
+        if glob(b, "*.tf") && !generated.contains(b) { return true; }
+    }
+    false
 }
 fn gen_files(context) {
     gen_provider(`${context.package_dir}/tofu`);

--- a/agent/scripts/lib/tofu_gen.rhai
+++ b/agent/scripts/lib/tofu_gen.rhai
@@ -1,4 +1,9 @@
 import "tofu" as tf;
+fn has_tofu_files(path) {
+    if !is_dir(path) { return false; }
+    let generated = ["00_vynil_vars.tf", "00_vynil_locals.tf"];
+    read_dir(path).any(|f| glob(basename(f), "*.tf") && !generated.contains(basename(f)))
+}
 fn gen_files(context) {
     gen_provider(`${context.package_dir}/tofu`);
     gen_locals(context);
@@ -49,30 +54,46 @@ fn gen_locals(context) {
 }`);
 }
 
+fn cached_version(namespace, name) {
+    let base = `/nonexistent/.terraform.d/plugins/registry.opentofu.org/${namespace}/${name}`;
+    if !is_dir(base) { return ""; }
+    let entries = read_dir(base);
+    if entries.len() == 0 { return ""; }
+    basename(entries[0])
+}
+fn provider_constraint(namespace, name, fallback) {
+    let ver = cached_version(namespace, name);
+    if ver != "" { `= ${ver}` } else { fallback }
+}
 fn gen_provider(path) {
     if ! is_file(`${path}/providers.tf`) {
-        file_write(`${path}/providers.tf`, "terraform {\n\
-  required_providers {\n\
-    kubernetes = {\n\
-        source = \"hashicorp/kubernetes\"\n\
-        version = \"~> 2.20.0\"\n\
-    }\n\
-    kubectl = {\n\
-        source = \"gavinbunney/kubectl\"\n\
-        version = \"~> 1.14.0\"\n\
-    }\n\
-  }\n\
-}\n\
-provider \"kubernetes\" {\n\
-    host = \"https://kubernetes.default.svc\"\n\
-    token = \"${file(\"/run/secrets/kubernetes.io/serviceaccount/token\")}\"\n\
-    cluster_ca_certificate = \"${file(\"/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}\"\n\
-}\n\
-provider \"kubectl\" {\n\
-    host = \"https://kubernetes.default.svc\"\n\
-    token = \"${file(\"/run/secrets/kubernetes.io/serviceaccount/token\")}\"\n\
-    cluster_ca_certificate = \"${file(\"/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}\"\n\
-    load_config_file       = false\n\
-}");
+        let k8s_ver     = provider_constraint("hashicorp",   "kubernetes", "~> 2.34.0");
+        let kubectl_ver = provider_constraint("gavinbunney", "kubectl",    "~> 1.16.0");
+        // HCL ${file(...)} syntax stored in variables to avoid Rhai interpolation conflicts
+        let sa_token = "${file(\"/run/secrets/kubernetes.io/serviceaccount/token\")}";
+        let sa_cert  = "${file(\"/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}";
+        file_write(`${path}/providers.tf`, `terraform {
+  required_providers {
+    kubernetes = {
+        source  = "hashicorp/kubernetes"
+        version = "${k8s_ver}"
+    }
+    kubectl = {
+        source  = "gavinbunney/kubectl"
+        version = "${kubectl_ver}"
+    }
+  }
+}
+provider "kubernetes" {
+    host                   = "https://kubernetes.default.svc"
+    token                  = "${sa_token}"
+    cluster_ca_certificate = "${sa_cert}"
+}
+provider "kubectl" {
+    host                   = "https://kubernetes.default.svc"
+    token                  = "${sa_token}"
+    cluster_ca_certificate = "${sa_cert}"
+    load_config_file       = false
+}`);
     }
 }

--- a/agent/scripts/service/delete.rhai
+++ b/agent/scripts/service/delete.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("delete_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -15,7 +16,7 @@ fn run(instance, context) {
             context = ctx;
         }
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         context = import_run("delete_tofu", instance, context);
     }
     if is_dir(`${context.package_dir}/others`) {

--- a/agent/scripts/service/install.rhai
+++ b/agent/scripts/service/install.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("install_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -26,7 +27,7 @@ fn run(instance, context) {
         }
         instance = get_service_instance(instance.metadata.namespace, instance.metadata.name);
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         context = import_run("install_tofu", instance, context);
         if type_of(ctx) == "map" {
             context = ctx;

--- a/agent/scripts/system/delete.rhai
+++ b/agent/scripts/system/delete.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("delete_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -9,7 +10,7 @@ fn run(instance, context) {
             context = ctx;
         }
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         context = import_run("delete_tofu", instance, context);
     }
     if is_dir(`${context.package_dir}/crds`) {

--- a/agent/scripts/system/install.rhai
+++ b/agent/scripts/system/install.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("install_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -12,7 +13,7 @@ fn run(instance, context) {
         update_k8s_crd_cache();
         instance = get_system_instance(instance.metadata.namespace, instance.metadata.name);
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         log_info(`Running tofu apply from ${context.package_dir}/tofu from ${instance.metadata.namespace} ${instance.metadata.name}`);
         context = import_run("install_tofu", instance, context);
         instance = get_system_instance(instance.metadata.namespace, instance.metadata.name);

--- a/agent/scripts/tenant/delete.rhai
+++ b/agent/scripts/tenant/delete.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("delete_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -15,7 +16,7 @@ fn run(instance, context) {
             context = ctx;
         }
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         context = import_run("delete_tofu", instance, context);
     }
     if is_dir(`${context.package_dir}/others`) {

--- a/agent/scripts/tenant/install.rhai
+++ b/agent/scripts/tenant/install.rhai
@@ -1,3 +1,4 @@
+import "tofu_gen" as tfg;
 fn run(instance, context) {
     let ctx = import_run("install_pre", instance, context);
     if type_of(ctx) == "map" {
@@ -17,7 +18,7 @@ fn run(instance, context) {
         }
         instance = get_tenant_instance(instance.metadata.namespace, instance.metadata.name);
     }
-    if is_dir(`${context.package_dir}/tofu`) {
+    if tfg::has_tofu_files(`${context.package_dir}/tofu`) {
         context = import_run("install_tofu", instance, context);
         if type_of(ctx) == "map" {
             context = ctx;

--- a/agent/tests/rhai_tofu_gen.rs
+++ b/agent/tests/rhai_tofu_gen.rs
@@ -1,0 +1,224 @@
+use common::rhaihandler::Script;
+use std::fs;
+
+fn make_lib_script() -> Script {
+    let base = env!("CARGO_MANIFEST_DIR");
+    Script::new_mock(
+        vec![format!("{base}/scripts/lib")],
+        vec![],
+        vec![],
+        Default::default(),
+    )
+}
+
+// ── has_tofu_files ────────────────────────────────────────────────────────────
+
+#[test]
+fn has_tofu_files_returns_false_for_nonexistent_dir() {
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("/tmp/vynil_test_nonexistent_dir_xyz")
+        "#,
+        )
+        .unwrap();
+    assert!(!result.as_bool().unwrap(), "non-existent dir should return false");
+}
+
+#[test]
+fn has_tofu_files_returns_false_for_empty_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+    let mut rhai = make_lib_script();
+    rhai.eval(&format!(
+        r#"
+        import "tofu_gen" as tg;
+        tg::has_tofu_files("{path}")
+    "#
+    ))
+    .unwrap()
+    .as_bool()
+    .map(|v| assert!(!v, "empty dir should return false"))
+    .unwrap();
+}
+
+#[test]
+fn has_tofu_files_returns_false_for_only_generated_files() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("00_vynil_vars.tf"), "").unwrap();
+    fs::write(dir.path().join("00_vynil_locals.tf"), "").unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(&format!(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("{path}")
+        "#
+        ))
+        .unwrap();
+    assert!(
+        !result.as_bool().unwrap(),
+        "only generated files should return false"
+    );
+}
+
+#[test]
+fn has_tofu_files_returns_true_for_user_tf_file() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("main.tf"), "# user resource").unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(&format!(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("{path}")
+        "#
+        ))
+        .unwrap();
+    assert!(result.as_bool().unwrap(), "main.tf should return true");
+}
+
+#[test]
+fn has_tofu_files_returns_true_for_providers_tf() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("providers.tf"), "terraform {}").unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(&format!(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("{path}")
+        "#
+        ))
+        .unwrap();
+    assert!(result.as_bool().unwrap(), "user providers.tf should return true");
+}
+
+#[test]
+fn has_tofu_files_returns_true_when_generated_and_user_files_coexist() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("00_vynil_vars.tf"), "").unwrap();
+    fs::write(dir.path().join("00_vynil_locals.tf"), "").unwrap();
+    fs::write(dir.path().join("main.tf"), "# user resource").unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(&format!(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("{path}")
+        "#
+        ))
+        .unwrap();
+    assert!(result.as_bool().unwrap(), "mixed dir should return true");
+}
+
+#[test]
+fn has_tofu_files_ignores_non_tf_files() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("config.yaml"), "key: value").unwrap();
+    fs::write(dir.path().join("README.md"), "docs").unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(&format!(
+            r#"
+            import "tofu_gen" as tg;
+            tg::has_tofu_files("{path}")
+        "#
+        ))
+        .unwrap();
+    assert!(
+        !result.as_bool().unwrap(),
+        "non-.tf files should not trigger tofu"
+    );
+}
+
+// ── gen_provider ──────────────────────────────────────────────────────────────
+
+#[test]
+fn gen_provider_creates_providers_tf_with_fallback_versions() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let _ = rhai
+        .eval(&format!(
+            r#"
+        import "tofu_gen" as tg;
+        tg::gen_provider("{path}")
+    "#
+        ))
+        .unwrap();
+
+    let content = fs::read_to_string(dir.path().join("providers.tf")).unwrap();
+    assert!(
+        content.contains("hashicorp/kubernetes"),
+        "should reference kubernetes provider"
+    );
+    assert!(
+        content.contains("gavinbunney/kubectl"),
+        "should reference kubectl provider"
+    );
+    assert!(
+        content.contains("kubernetes.default.svc"),
+        "should configure in-cluster auth"
+    );
+    // fallback constraints present when no cache
+    assert!(
+        content.contains("~> 2.34.0") || content.contains("= 2."),
+        "should have a kubernetes version constraint"
+    );
+}
+
+#[test]
+fn gen_provider_does_not_overwrite_existing_providers_tf() {
+    let dir = tempfile::tempdir().unwrap();
+    let custom = "# my custom providers";
+    fs::write(dir.path().join("providers.tf"), custom).unwrap();
+    let path = dir.path().to_str().unwrap().to_string();
+
+    let mut rhai = make_lib_script();
+    let _ = rhai
+        .eval(&format!(
+            r#"
+        import "tofu_gen" as tg;
+        tg::gen_provider("{path}")
+    "#
+        ))
+        .unwrap();
+
+    let content = fs::read_to_string(dir.path().join("providers.tf")).unwrap();
+    assert_eq!(content, custom, "existing providers.tf must not be overwritten");
+}
+
+// ── provider_constraint ───────────────────────────────────────────────────────
+
+#[test]
+fn provider_constraint_returns_fallback_when_cache_absent() {
+    let mut rhai = make_lib_script();
+    let result = rhai
+        .eval(
+            r#"
+            import "tofu_gen" as tg;
+            tg::provider_constraint("hashicorp", "kubernetes", "~> 2.34.0")
+        "#,
+        )
+        .unwrap();
+    // When the real plugin cache is absent (test env), fallback is returned
+    let s = result.to_string();
+    assert!(
+        s.contains("2.34") || s.starts_with('='),
+        "should return fallback or cached version, got: {s}"
+    );
+}


### PR DESCRIPTION
Fixes #212

## Summary

- `has_tofu_files()` replaces the bare `is_dir(tofu/)` check in all install/delete scripts (tenant, service, system): tofu only runs if the `tofu/` directory contains at least one `.tf` file that is not a vynil-generated file (`00_vynil_vars.tf`, `00_vynil_locals.tf`)
- Provider versions in the generated `providers.tf` are now read at runtime from the plugin cache directory (`/nonexistent/.terraform.d/plugins/registry.opentofu.org/...`) and emitted as exact `= x.y.z` constraints — the fallback to `~> 2.34.0` / `~> 1.16.0` applies only when the cache is absent (dev/test). No more manual version bumps when the image is rebuilt.
- `array.any(Fn)` is not available in this version of Rhai — rewrote with an explicit `for` loop

## Test plan

- [ ] `cargo test` — 10 new regression tests in `rhai_tofu_gen.rs` covering `has_tofu_files` (empty dir, only generated files, user .tf present, non-.tf files), `gen_provider` (creates file with correct content, does not overwrite), and `provider_constraint` (fallback when cache absent)
- [ ] Deploy updated image and verify xlrelease install no longer triggers tofu