### PR TITLE
fix(backup): replace redis-cli --rdb with kubectl exec SAVE + kubectl cp

### DIFF
--- a/agent/scripts/tenant/backup_prepare_redis.rhai
+++ b/agent/scripts/tenant/backup_prepare_redis.rhai
@@ -2,9 +2,20 @@ fn run(context) {
     import_run("backup_prepare_redis_pre", context);
     for redis in context.redis_list {
         log_info(`Dumping redis target: ${redis}`);
-        let rc = shell_run("redis-cli -h \"${"+redis+"_host}\" --pass \"${"+redis+"_password}\" --no-auth-warning --rdb /backup/redis_"+redis+".rdb");
+        let ns  = context.namespace;
+        let sts = get_env(`${redis}_sts`);
+        let pass = get_env(`${redis}_password`);
+        let pod = shell_output(`kubectl -n ${ns} get pods -l app=${sts} --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}'`);
+        if pod == "" {
+            throw `No running pod found for ${redis} (sts: ${sts})`;
+        }
+        let rc = shell_run(`kubectl -n ${ns} exec ${pod} -- redis-cli --no-auth-warning -a "${pass}" SAVE`);
         if rc != 0 {
-            throw `redis-cli rdb dump failed for ${redis}`;
+            throw `redis SAVE failed for ${redis}`;
+        }
+        let rc = shell_run(`kubectl -n ${ns} cp ${pod}:/data/dump.rdb /backup/redis_${redis}.rdb`);
+        if rc != 0 {
+            throw `kubectl cp failed for ${redis}`;
         }
     }
     import_run("backup_prepare_redis_post", context);

--- a/agent/scripts/tenant/restore_redis.rhai
+++ b/agent/scripts/tenant/restore_redis.rhai
@@ -3,27 +3,51 @@ fn run(context) {
     let ns = context.namespace;
     for redis in context.redis_list {
         log_info(`Starting Redis restore for ${redis}`);
-        let kind = get_env(`${redis}_kind`);
         let sts  = get_env(`${redis}_sts`);
-        let pod  = shell_output(`kubectl -n ${ns} get pods -l app=${sts} -o jsonpath='{.items[0].metadata.name}'`);
-        if pod == "" {
-            throw `No pod found for redis ${redis} (statefulset: ${sts})`;
+        let pass = get_env(`${redis}_password`);
+
+        // Detect whether the workload is a StatefulSet or a Deployment
+        let is_sts = shell_run(`kubectl -n ${ns} get statefulset ${sts} 2>/dev/null`) == 0;
+        let resource = if is_sts { "statefulset" } else { "deployment" };
+
+        // Scale down to 1 replica to avoid cross-replica corruption during restore
+        let replicas = parse_int(shell_output(
+            `kubectl -n ${ns} get ${resource} ${sts} -o jsonpath='{.spec.replicas}'`));
+        if replicas > 1 {
+            let rc = shell_run(`kubectl -n ${ns} scale ${resource}/${sts} --replicas=1`);
+            if rc != 0 { throw `scale down failed for ${redis}`; }
+            let rc = shell_run(`kubectl -n ${ns} rollout status --timeout=5m ${resource}/${sts}`);
+            if rc != 0 { throw `scale down wait failed for ${redis}`; }
         }
+
+        let pod = shell_output(`kubectl -n ${ns} get pods -l app=${sts} -o jsonpath='{.items[0].metadata.name}'`);
+        if pod == "" {
+            throw `No pod found for redis ${redis} (${resource}: ${sts})`;
+        }
+
+        // Disable auto-save on the running pod so it cannot overwrite our dump on shutdown.
+        // CONFIG SET is runtime-only: the new pod re-reads its static config on startup,
+        // so auto-save is automatically re-enabled after the rollout restart.
+        shell_run(`kubectl -n ${ns} exec ${pod} -- redis-cli --no-auth-warning -a "${pass}" CONFIG SET save ""`);
+
         let rc = shell_run(`kubectl -n ${ns} cp /backup/redis_${redis}.rdb ${pod}:/data/dump.rdb`);
         if rc != 0 {
             throw `kubectl cp failed for ${redis}`;
         }
-        let rc2 = if kind == "Dragonfly" {
-            shell_run(`kubectl -n ${ns} rollout restart deployment/${sts}`)
-        } else {
-            shell_run(`kubectl -n ${ns} rollout restart statefulset/${sts}`)
-        };
-        if rc2 != 0 {
+
+        let rc = shell_run(`kubectl -n ${ns} rollout restart ${resource}/${sts}`);
+        if rc != 0 {
             throw `rollout restart failed for ${redis}`;
         }
-        let rc3 = shell_run(`kubectl -n ${ns} rollout status --timeout=5m statefulset/${sts}`);
-        if rc3 != 0 {
-            throw `rollout status check failed for ${redis}`;
+        let rc = shell_run(`kubectl -n ${ns} rollout status --timeout=5m ${resource}/${sts}`);
+        if rc != 0 {
+            throw `rollout status failed for ${redis}`;
+        }
+
+        // Scale back to the original replica count
+        if replicas > 1 {
+            shell_run(`kubectl -n ${ns} scale ${resource}/${sts} --replicas=${replicas}`);
+            shell_run(`kubectl -n ${ns} rollout status --timeout=5m ${resource}/${sts}`);
         }
     }
     import_run("restore_redis_post", context);

--- a/agent/tests/rhai_backup_redis.rs
+++ b/agent/tests/rhai_backup_redis.rs
@@ -1,0 +1,389 @@
+use common::rhaihandler::Script;
+
+fn make_tenant_script() -> Script {
+    let base = env!("CARGO_MANIFEST_DIR");
+    Script::new_mock(
+        vec![format!("{base}/scripts/lib"), format!("{base}/scripts/tenant")],
+        vec![],
+        vec![],
+        Default::default(),
+    )
+}
+
+fn context(namespace: &str, redis_list: &[&str]) -> String {
+    let list = redis_list
+        .iter()
+        .map(|s| format!("\"{s}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("#{{ namespace: \"{namespace}\", redis_list: [{list}] }}")
+}
+
+// ─── backup_prepare_redis ────────────────────────────────────────────────────
+
+#[test]
+fn backup_redis_empty_list_completes() {
+    // Empty redis_list: no shell calls, should complete without errors.
+    let mut rhai = make_tenant_script();
+    let ctx = context("test-ns", &[]);
+    let result = rhai.eval(&format!(
+        r#"import "backup_prepare_redis" as bk; bk::run({ctx});"#
+    ));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn backup_redis_nominal() {
+    // All kubectl commands succeed; expect the script to complete without throwing.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"      { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) { "my-dragonfly-0" }
+        fn shell_run(cmd)    { 0 }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(
+        r#"import "backup_prepare_redis" as bk; bk::run({ctx});"#
+    ));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn backup_redis_pod_not_found_throws() {
+    // kubectl get pods returns empty string → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) { "" }
+        fn shell_run(cmd)    { 0 }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(
+        r#"import "backup_prepare_redis" as bk; bk::run({ctx});"#
+    ));
+    assert!(result.is_err(), "Expected throw when no pod found");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("No running pod found"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn backup_redis_save_failure_throws() {
+    // SAVE command returns non-zero → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) { "my-dragonfly-0" }
+        fn shell_run(cmd) {
+            if cmd.contains("SAVE") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(
+        r#"import "backup_prepare_redis" as bk; bk::run({ctx});"#
+    ));
+    assert!(result.is_err(), "Expected throw when SAVE fails");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("redis SAVE failed"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn backup_redis_cp_failure_throws() {
+    // kubectl cp returns non-zero → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) { "my-dragonfly-0" }
+        fn shell_run(cmd) {
+            if cmd.contains(" cp ") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(
+        r#"import "backup_prepare_redis" as bk; bk::run({ctx});"#
+    ));
+    assert!(result.is_err(), "Expected throw when kubectl cp fails");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("kubectl cp failed"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+// ─── restore_redis ────────────────────────────────────────────────────────────
+
+#[test]
+fn restore_redis_empty_list_completes() {
+    // Empty redis_list: no shell calls, should complete without errors.
+    let mut rhai = make_tenant_script();
+    let ctx = context("test-ns", &[]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn restore_redis_statefulset_single_replica() {
+    // StatefulSet with 1 replica: no scale needed, full restore flow completes.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")    { "my-dragonfly-0" }
+            else if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) { 0 }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn restore_redis_statefulset_multiple_replicas() {
+    // StatefulSet with 2 replicas: scale down to 1 then scale back to 2.
+    // All commands succeed; script must complete without error.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-dragonfly-0" }
+            else if cmd.contains("replicas") { "2" }
+            else { "" }
+        }
+        fn shell_run(cmd) { 0 }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn restore_redis_deployment_detected() {
+    // When kubectl get statefulset returns non-zero, resource type is "deployment".
+    // Script must still complete successfully with all mock commands succeeding.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "myredis_sts"           { "my-redis" }
+            else if name == "myredis_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-redis-0" }
+            else if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) {
+            // Simulate statefulset not found → use deployment
+            if cmd.contains("get statefulset") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["myredis"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
+fn restore_redis_pod_not_found_throws() {
+    // kubectl get pods returns empty string → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) { 0 }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_err(), "Expected throw when no pod found");
+    let msg = format!("{:?}", result.err());
+    assert!(msg.contains("No pod found"), "Unexpected error message: {msg}");
+}
+
+#[test]
+fn restore_redis_cp_failure_throws() {
+    // kubectl cp fails → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-dragonfly-0" }
+            else if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) {
+            if cmd.contains(" cp ") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_err(), "Expected throw when kubectl cp fails");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("kubectl cp failed"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn restore_redis_scale_down_required_for_multiple_replicas() {
+    // Old code had no scale logic: would succeed even when scale fails.
+    // New code scales before restore → propagates the failure.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-dragonfly-0" }
+            else if cmd.contains("replicas") { "2" }
+            else { "" }
+        }
+        fn shell_run(cmd) {
+            if cmd.contains("scale") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_err(), "Expected throw when scale down fails");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("scale down failed"),
+        "Unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn restore_redis_resource_type_detection_uses_deployment() {
+    // Old code hardcoded rollout status to statefulset even for Dragonfly (Deployment).
+    // New code detects resource type: if get statefulset fails → use deployment.
+    // Test: make rollout status statefulset fail → old code would throw, new code uses deployment.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "myredis_sts"           { "my-redis" }
+            else if name == "myredis_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-redis-0" }
+            else if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) {
+            // "get statefulset" not found → resource is deployment
+            // "statefulset/" anywhere else → old code would use it for rollout → fails
+            if cmd.contains("get statefulset") { 1 }
+            else if cmd.contains("statefulset/") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["myredis"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(
+        result.is_ok(),
+        "Expected success when resource type is detected as deployment, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn restore_redis_rollout_restart_failure_throws() {
+    // rollout restart fails → script must throw.
+    let mut rhai = make_tenant_script();
+    rhai.add_code(
+        r#"
+        fn get_env(name) {
+            if name == "dragonfly_sts"           { "my-dragonfly" }
+            else if name == "dragonfly_password" { "secret" }
+            else { "" }
+        }
+        fn shell_output(cmd) {
+            if cmd.contains("get pods")      { "my-dragonfly-0" }
+            else if cmd.contains("replicas") { "1" }
+            else { "" }
+        }
+        fn shell_run(cmd) {
+            if cmd.contains("rollout restart") { 1 }
+            else { 0 }
+        }
+        "#,
+    );
+    let ctx = context("test-ns", &["dragonfly"]);
+    let result = rhai.eval(&format!(r#"import "restore_redis" as rs; rs::run({ctx});"#));
+    assert!(result.is_err(), "Expected throw when rollout restart fails");
+    let msg = format!("{:?}", result.err());
+    assert!(
+        msg.contains("rollout restart failed"),
+        "Unexpected error message: {msg}"
+    );
+}


### PR DESCRIPTION
## Problème

`backup_prepare_redis.rhai` utilisait `redis-cli --rdb` qui s'appuie sur les commandes `REPLCONF`/`SYNC` du protocole de réplication. Ces commandes ne sont pas supportées par Dragonfly :

```
REPLCONF rdb-only error: ERR syntax error
SYNC with master failed: -ERR unknown command `SYNC`
```

`restore_redis.rhai` avait deux bugs :
1. `rollout restart deployment/${sts}` hardcodé pour Dragonfly alors que Dragonfly est un **StatefulSet**
2. `rollout status statefulset/${sts}` toujours utilisé même quand le type détecté est `deployment`
3. Pas de gestion des clusters multi-réplicas (risque de corruption par réplication)
4. Pas de désactivation de l'auto-save avant la copie du dump (risque d'écrasement au shutdown)

## Solution

**backup_prepare_redis** : remplacer `redis-cli --rdb` par `kubectl exec ... redis-cli SAVE` suivi de `kubectl cp`. Approche indépendante du protocole, identique pour tous les types Redis-compatibles.

**restore_redis** :
- Détection dynamique du type de ressource : `kubectl get statefulset` → 0 = StatefulSet, sinon Deployment
- Scale down à 1 réplica avant restore si cluster > 1 réplica (évite la corruption cross-réplica)
- `CONFIG SET save ""` sur le pod courant avant la copie (désactive l'auto-save runtime pour éviter l'écrasement au shutdown — le nouveau pod relit sa config statique après `rollout restart`)
- `rollout status` utilise le type de ressource détecté

## Tests

14 tests TDD ajoutés dans `agent/tests/rhai_backup_redis.rs` :
- 5 tests échouaient sur l'ancien code (signal TDD)
- 14/14 passent avec la nouvelle implémentation

Closes #219