### PR TITLE
fix(scan): replace log_error with silent positive filter for non-semver tags

### DIFF
--- a/agent/scripts/boxes/scan.rhai
+++ b/agent/scripts/boxes/scan.rhai
@@ -9,18 +9,13 @@ fn maturity_filter(str, maturity) {
 }
 
 fn security_filter(v) {
-    try{
-        let x = semver_from(v);
-        return true
-    }catch(e){
-        log_error(v);
-        if type_of(e) == "string" {
-            log_warn(e);
-        } else {
-            log_warn(json_encode(e));
-        }
+    if v.len() == 0 { return false; }
+    let c = v.sub_string(0, 1);
+    if c != "v" && (c < "0" || c > "9") { return false; }
+    try { semver_from(v); return true } catch(e) {
+        log_warn(`skipping non-semver tag ${v}`);
     }
-    return false
+    false
 }
 
 fn scan_image_with_maturity(image, reg, all_tags, maturity) {

--- a/agent/scripts/packages/build.rhai
+++ b/agent/scripts/packages/build.rhai
@@ -2,18 +2,13 @@ import "copy_dir" as copy;
 import "package_yaml" as pck;
 
 fn security_filter(v) {
-    try{
-        let x = semver_from(v);
-        return true
-    }catch(e){
-        log_error(v);
-        if type_of(e) == "string" {
-            log_warn(e);
-        } else {
-            log_warn(json_encode(e));
-        }
+    if v.len() == 0 { return false; }
+    let c = v.sub_string(0, 1);
+    if c != "v" && (c < "0" || c > "9") { return false; }
+    try { semver_from(v); return true } catch(e) {
+        log_warn(`skipping non-semver tag ${v}`);
     }
-    return false
+    false
 }
 
 fn improve_package(src, dest) {

--- a/agent/tests/rhai_build.rs
+++ b/agent/tests/rhai_build.rs
@@ -1,0 +1,86 @@
+use common::rhaihandler::Script;
+
+fn make_build_script() -> Script {
+    let base = env!("CARGO_MANIFEST_DIR");
+    Script::new_mock(
+        vec![format!("{base}/scripts/packages"), format!("{base}/scripts/lib")],
+        vec![],
+        vec![],
+        Default::default(),
+    )
+}
+
+// ── security_filter in build.rhai — TDD ──────────────────────────────────
+// build.rhai contains a security_filter function identical to the one in scan.rhai.
+// Old code calls log_error() for every non-semver tag, producing ERROR noise.
+// New code must return false silently for tags that do not start with a digit or 'v'.
+
+#[test]
+fn build_security_filter_cosign_tag_no_error_log() {
+    // sha256-*.sig tags (Cosign signatures) must be silently rejected.
+    // Old code: log_error("sha256-deadbeef.sig") → mock throws → test fails.
+    // New code: starts with 's' → returns false silently → test passes.
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("sha256-deadbeef.sig")"#);
+    assert!(result.is_ok(), "Expected no error log: {:?}", result.err());
+    assert!(
+        !result.unwrap().as_bool().unwrap(),
+        "Expected false for cosign tag"
+    );
+}
+
+#[test]
+fn build_security_filter_trivy_tag_no_error_log() {
+    // trivy-* tags must be silently rejected.
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("trivy--apps-auth")"#);
+    assert!(result.is_ok(), "Expected no error log: {:?}", result.err());
+    assert!(
+        !result.unwrap().as_bool().unwrap(),
+        "Expected false for trivy tag"
+    );
+}
+
+#[test]
+fn build_security_filter_latest_tag_no_error_log() {
+    // "latest" and other non-versioned tags must be silently rejected.
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("latest")"#);
+    assert!(result.is_ok(), "Expected no error log: {:?}", result.err());
+    assert!(!result.unwrap().as_bool().unwrap(), "Expected false for 'latest'");
+}
+
+#[test]
+fn build_security_filter_semver_tag_accepted() {
+    // Valid semver tags (starting with digit) must return true.
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("1.2.3")"#);
+    assert!(result.is_ok(), "Expected success: {:?}", result.err());
+    assert!(result.unwrap().as_bool().unwrap(), "Expected true for '1.2.3'");
+}
+
+#[test]
+fn build_security_filter_v_prefixed_semver_accepted() {
+    // Tags starting with 'v' followed by semver must return true.
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("v2.0.0")"#);
+    assert!(result.is_ok(), "Expected success: {:?}", result.err());
+    assert!(result.unwrap().as_bool().unwrap(), "Expected true for 'v2.0.0'");
+}
+
+#[test]
+fn build_security_filter_empty_string_rejected() {
+    let mut script = make_build_script();
+    script.add_code(r#"fn log_error(msg) { throw `unexpected error log: ${msg}`; }"#);
+    let result = script.eval(r#"import "build" as b; b::security_filter("")"#);
+    assert!(result.is_ok(), "Expected success: {:?}", result.err());
+    assert!(
+        !result.unwrap().as_bool().unwrap(),
+        "Expected false for empty string"
+    );
+}

--- a/agent/tests/rhai_scan.rs
+++ b/agent/tests/rhai_scan.rs
@@ -166,6 +166,65 @@ fn scan_branch_full_when_no_filter() {
     assert_eq!(result.unwrap().into_string().unwrap(), "full");
 }
 
+// ── security_filter — TDD ────────────────────────────────────────────────
+
+fn build_jukebox_http_mock() -> K8sJukeBoxMock {
+    let json = serde_json::json!({
+        "kind": "JukeBox",
+        "metadata": {"name": "test-box"},
+        "spec": {
+            "source": {"http": {"url": "http://test.local/packages"}},
+            "maturity": "stable",
+            "schedule": "0 * * * *"
+        },
+        "status": {"conditions": [], "packages": []}
+    });
+    K8sJukeBoxMock {
+        obj: serde_json::from_str(&serde_json::to_string(&json).unwrap()).unwrap(),
+    }
+}
+
+#[test]
+fn security_filter_cosign_and_trivy_tags_no_error_log() {
+    // Old code calls log_error() for every non-semver tag (cosign, trivy, etc.).
+    // New code must silently return false for tags that do not start with a digit or 'v'.
+    // HTTP source path is used so that security_filter is called on p.tag via
+    // compute_waypoints_from_packages — no registry method mocking needed.
+    // Fails on old code (log_error throws); passes on new code (silent filter).
+    let base = env!("CARGO_MANIFEST_DIR");
+    let (mut script, _) = make_scan_script(vec![]);
+
+    script.add_code(
+        r#"
+        fn log_error(msg) { throw `unexpected error log: ${msg}`; }
+        fn http_get_yaml(url, auth_type, credential) {
+            if url.contains("index.yaml") {
+                #{ packages: [#{ category: "test", name: "pkg", file: "pkg.yaml" }] }
+            } else {
+                [
+                    #{ tag: "sha256-deadbeef.sig", registry: "r.io", image: "test/img",
+                       metadata: #{}, requirements: [] },
+                    #{ tag: "trivy--apps-foo", registry: "r.io", image: "test/img",
+                       metadata: #{}, requirements: [] },
+                    #{ tag: "1.2.3", registry: "r.io", image: "test/img",
+                       metadata: #{}, requirements: [] }
+                ]
+            }
+        }
+        "#,
+    );
+    script.ctx.set_value("box", build_jukebox_http_mock());
+    let args = serde_json::json!({"namespace": "test-ns"});
+    script.set_dynamic("args", &args);
+
+    let result = script.run_file(&PathBuf::from(format!("{base}/scripts/boxes/scan.rhai")));
+    assert!(
+        result.is_ok(),
+        "Expected no error log for cosign/trivy tags: {:?}",
+        result.err()
+    );
+}
+
 // ── Intégration — scan.rhai complet ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Problème

`security_filter` dans `scan.rhai` (boxes) et `build.rhai` (packages) appelait `log_error()` pour chaque tag qui échouait `semver_from()`. Les tags Harbor Cosign et Trivy sont des tags normaux dans les repositories OCI :

- Cosign : `sha256-46de4a9f4c3b9094....sig`
- Trivy : `trivy--apps-authentik--docker-io-sebt3-vynil-agent-0-7-4`

Résultat : des centaines de lignes ERROR par scan, noyant les vraies erreurs.

## Solution

Logique de filtre **positive** : seuls les tags qui commencent par un chiffre (`0`–`9`) ou `v` peuvent être des versions Vynil. Tout le reste est silencieusement écarté avant même d'appeler `semver_from()`.

```rhai
fn security_filter(v) {
    if v.len() == 0 { return false; }
    let c = v.sub_string(0, 1);
    if c != "v" && (c < "0" || c > "9") { return false; }
    try { semver_from(v); return true } catch(e) {
        log_warn(`skipping non-semver tag ${v}`);
    }
    false
}
```

- `sha256-abc.sig` → commence par `s` → silencieux ✓
- `trivy--foo` → commence par `t` → silencieux ✓
- `latest`, `main` → silencieux ✓
- `1.2.3`, `v2.0.0` → semver valide → accepté ✓
- `1.2.x-invalide` → commence par `1` mais semver échoue → `WARN` (cas inattendu, mérite attention) ✓

## Fichiers modifiés

- `agent/scripts/boxes/scan.rhai` — `security_filter` (lignes 11-17)
- `agent/scripts/packages/build.rhai` — `security_filter` (lignes 4-10) — même bug, même correctif

## Tests TDD

7 tests ajoutés :
- `rhai_scan.rs` : `security_filter_cosign_and_trivy_tags_no_error_log` — test d'intégration via chemin HTTP source, `log_error` mocké pour lever une exception. Échoue sur l'ancien code, passe sur le nouveau.
- `rhai_build.rs` (nouveau) : 6 tests unitaires via `import "build"` — cosign, trivy, latest rejetés silencieusement ; `1.2.3` et `v2.0.0` acceptés ; chaîne vide rejetée. 4/6 échouaient sur l'ancien code.

Closes #220