### PR TITLE
fix(lint): detect silent test failures, unsupported object schemas, and forbidden context access

### DIFF
--- a/agent/src/linting/rhai_checker.rs
+++ b/agent/src/linting/rhai_checker.rs
@@ -815,6 +815,18 @@ fn check_wrong_api_mode(file: &Path, ast: &AST) -> Vec<LintFinding> {
     findings
 }
 
+/// Extract the leftmost property name from a Rhai dot-chain RHS.
+///
+/// Rhai compiles `a.b.c` right-associatively as `Dot(Variable(a), Dot(Property(b), Property(c)))`,
+/// so the first property accessed on `a` is the `lhs` of the nested `Dot`, not a direct child.
+fn first_property_in_dot_chain(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Property(prop_data, _) => Some(&prop_data.2),
+        Expr::Dot(inner_data, _, _) => first_property_in_dot_chain(&inner_data.lhs),
+        _ => None,
+    }
+}
+
 fn check_wrong_package_type(ast: &AST, file: &Path, pkg: &VynilPackageSource) -> Vec<LintFinding> {
     let mut findings = Vec::new();
 
@@ -828,16 +840,44 @@ fn check_wrong_package_type(ast: &AST, file: &Path, pkg: &VynilPackageSource) ->
     }
 
     ast.walk(&mut |nodes: &[ASTNode]| {
-        if let Some(ASTNode::Expr(Expr::Variable(var_data, _, pos))) = nodes.last() {
-            let (_, name, _, _) = &**var_data;
-            if *name == "tenant" {
-                findings.push(LintFinding {
-                    rule: "rhai/wrong-package-type".to_string(),
-                    level: LintLevel::Warn,
-                    file: file.to_path_buf(),
-                    line: pos.line(),
-                    message: "System packages cannot access tenant context".to_string(),
-                });
+        if let Some(ASTNode::Expr(expr)) = nodes.last() {
+            match expr {
+                Expr::Variable(var_data, _, pos) => {
+                    let (_, name, _, _) = &**var_data;
+                    if *name == "tenant" {
+                        findings.push(LintFinding {
+                            rule: "rhai/wrong-package-type".to_string(),
+                            level: LintLevel::Warn,
+                            file: file.to_path_buf(),
+                            line: pos.line(),
+                            message: "System packages cannot access tenant context".to_string(),
+                        });
+                    }
+                }
+                Expr::Dot(data, _, _) => {
+                    if let Expr::Variable(var_data, _, _) = &data.lhs {
+                        let (_, var_name, _, _) = &**var_data;
+                        if *var_name == "context" {
+                            // In Rhai's AST, `context.namespace.ha` is right-associative:
+                            // Dot(Variable("context"), Dot(Property("namespace"), Property("ha")))
+                            // So the first property is the leftmost node of the rhs chain.
+                            if let Some(prop) = first_property_in_dot_chain(&data.rhs)
+                                && (prop == "namespace" || prop == "tenant")
+                            {
+                                findings.push(LintFinding {
+                                    rule: "rhai/wrong-package-type".to_string(),
+                                    level: LintLevel::Warn,
+                                    file: file.to_path_buf(),
+                                    line: data.rhs.position().line(),
+                                    message: format!(
+                                        "System packages cannot access context.{prop} (not available for type:system)",
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
         }
         true
@@ -1689,6 +1729,60 @@ mod tests {
         assert!(
             !findings.iter().any(|f| f.rule == "rhai/k8s-resource-plural"),
             "No warning expected for singular kind"
+        );
+    }
+
+    #[test]
+    fn context_namespace_access_in_system_package_warns() {
+        let base_dir = get_fixture_dir("rhai-checks");
+        let pkg = read_package_yaml(&base_dir.join("package.yaml")).expect("Failed to load package");
+        let config = LintConfig::default();
+        let mut checker = RhaiChecker::new(&base_dir, &base_dir, None, &pkg, &config);
+
+        let source = r#"fn run(instance, context) {
+    let replicas = if context.namespace.ha { 2 } else { 1 };
+}"#;
+        let findings = checker.check_file(&PathBuf::from("scripts/install.rhai"), source);
+
+        assert!(
+            findings.iter().any(|f| f.rule == "rhai/wrong-package-type"),
+            "Expected rhai/wrong-package-type finding for context.namespace access in system package"
+        );
+    }
+
+    #[test]
+    fn context_tenant_access_in_system_package_warns() {
+        let base_dir = get_fixture_dir("rhai-checks");
+        let pkg = read_package_yaml(&base_dir.join("package.yaml")).expect("Failed to load package");
+        let config = LintConfig::default();
+        let mut checker = RhaiChecker::new(&base_dir, &base_dir, None, &pkg, &config);
+
+        let source = r#"fn run(instance, context) {
+    let name = context.tenant.name;
+}"#;
+        let findings = checker.check_file(&PathBuf::from("scripts/install.rhai"), source);
+
+        assert!(
+            findings.iter().any(|f| f.rule == "rhai/wrong-package-type"),
+            "Expected rhai/wrong-package-type finding for context.tenant access in system package"
+        );
+    }
+
+    #[test]
+    fn context_cluster_access_in_system_package_no_warn() {
+        let base_dir = get_fixture_dir("rhai-checks");
+        let pkg = read_package_yaml(&base_dir.join("package.yaml")).expect("Failed to load package");
+        let config = LintConfig::default();
+        let mut checker = RhaiChecker::new(&base_dir, &base_dir, None, &pkg, &config);
+
+        let source = r#"fn run(instance, context) {
+    let replicas = if context.cluster.ha { 2 } else { 1 };
+}"#;
+        let findings = checker.check_file(&PathBuf::from("scripts/install.rhai"), source);
+
+        assert!(
+            !findings.iter().any(|f| f.rule == "rhai/wrong-package-type"),
+            "context.cluster is valid in system packages, should not warn"
         );
     }
 }

--- a/agent/src/package/lint.rs
+++ b/agent/src/package/lint.rs
@@ -442,6 +442,18 @@ fn check_options(
                 message: format!("Option '{}': no description provided", key),
             });
         }
+        if obj.get("type").and_then(|t| t.as_str()) == Some("object") && obj.contains_key("properties") {
+            collector.add(crate::linting::LintFinding {
+                rule: "package/object-properties-unsupported".to_string(),
+                level: crate::linting::LintLevel::Warn,
+                file: manifest.clone(),
+                line,
+                message: format!(
+                    "Option '{}': nested 'properties' sub-schema is not supported for type:object; use a flat 'default:' map at the option root instead",
+                    key
+                ),
+            });
+        }
     }
 }
 
@@ -833,5 +845,70 @@ mod tests {
         let mut collector = crate::linting::LintResultCollector::new();
         check_manifest_fields(&package, std::path::Path::new(""), &mut collector);
         assert!(collector.has_errors());
+    }
+
+    #[test]
+    fn check_options_object_with_nested_properties_warns() {
+        let mut package = make_valid_package();
+        let mut options = std::collections::BTreeMap::new();
+        options.insert(
+            "solver_settings".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "description": "Solver settings",
+                "properties": {
+                    "ingress_class": { "type": "string", "default": "traefik" }
+                }
+            }),
+        );
+        package.options = Some(options);
+        let mut collector = crate::linting::LintResultCollector::new();
+        check_options(&package, std::path::Path::new(""), &mut collector);
+        let text = collector.to_text(crate::linting::LintLevel::Info);
+        assert!(
+            text.contains("solver_settings"),
+            "warning must mention the option key"
+        );
+        assert!(text.contains("properties"), "warning must mention 'properties'");
+    }
+
+    #[test]
+    fn check_options_object_with_flat_default_passes() {
+        let mut package = make_valid_package();
+        let mut options = std::collections::BTreeMap::new();
+        options.insert(
+            "solver_settings".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "description": "Solver settings",
+                "default": { "ingress_class": "traefik" }
+            }),
+        );
+        package.options = Some(options);
+        let mut collector = crate::linting::LintResultCollector::new();
+        check_options(&package, std::path::Path::new(""), &mut collector);
+        assert!(!collector.has_errors());
+        let text = collector.to_text(crate::linting::LintLevel::Info);
+        assert!(
+            !text.contains("properties"),
+            "no warning expected for valid flat default"
+        );
+    }
+
+    #[test]
+    fn check_options_non_object_with_properties_key_no_extra_warn() {
+        let mut package = make_valid_package();
+        let mut options = std::collections::BTreeMap::new();
+        options.insert(
+            "my_schema".to_string(),
+            serde_json::json!({
+                "type": "string",
+                "description": "A string, not an object"
+            }),
+        );
+        package.options = Some(options);
+        let mut collector = crate::linting::LintResultCollector::new();
+        check_options(&package, std::path::Path::new(""), &mut collector);
+        assert!(!collector.has_errors());
     }
 }

--- a/agent/src/package/test.rs
+++ b/agent/src/package/test.rs
@@ -143,8 +143,15 @@ pub async fn run(args: &Parameters) -> Result<()> {
         for t in handler.list_tests() {
             println!("{t}");
         }
+        return Ok(());
     }
 
+    if !handler.results.all_passed() {
+        return Err(common::Error::TestFailure(
+            handler.results.total_failed(),
+            handler.results.total_asserts(),
+        ));
+    }
 
     Ok(())
 }

--- a/agent/src/testing/result.rs
+++ b/agent/src/testing/result.rs
@@ -139,3 +139,92 @@ impl Default for TestResultCollector {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::VynilAssertResult;
+
+    fn passing_assert(name: &str) -> VynilAssertResult {
+        VynilAssertResult {
+            name: name.to_string(),
+            description: None,
+            passed: true,
+            message: "ok".to_string(),
+        }
+    }
+
+    fn failing_assert(name: &str) -> VynilAssertResult {
+        VynilAssertResult {
+            name: name.to_string(),
+            description: None,
+            passed: false,
+            message: "no match".to_string(),
+        }
+    }
+
+    #[test]
+    fn all_passed_empty_collector() {
+        let c = TestResultCollector::new();
+        assert!(c.all_passed());
+    }
+
+    #[test]
+    fn all_passed_when_all_asserts_pass() {
+        let mut c = TestResultCollector::new();
+        c.add(
+            "t1".to_string(),
+            vec![passing_assert("a"), passing_assert("b")],
+            std::time::Duration::ZERO,
+        );
+        assert!(c.all_passed());
+    }
+
+    #[test]
+    fn all_passed_false_when_one_assert_fails() {
+        let mut c = TestResultCollector::new();
+        c.add(
+            "t1".to_string(),
+            vec![passing_assert("a"), failing_assert("b")],
+            std::time::Duration::ZERO,
+        );
+        assert!(!c.all_passed());
+    }
+
+    #[test]
+    fn all_passed_false_when_all_asserts_fail() {
+        let mut c = TestResultCollector::new();
+        c.add(
+            "t1".to_string(),
+            vec![failing_assert("a"), failing_assert("b")],
+            std::time::Duration::ZERO,
+        );
+        assert!(!c.all_passed());
+    }
+
+    #[test]
+    fn total_failed_counts_only_failed() {
+        let mut c = TestResultCollector::new();
+        c.add(
+            "t1".to_string(),
+            vec![passing_assert("a"), failing_assert("b"), failing_assert("c")],
+            std::time::Duration::ZERO,
+        );
+        assert_eq!(c.total_failed(), 2);
+        assert_eq!(c.total_passed(), 1);
+    }
+
+    #[test]
+    fn to_text_contains_results_summary() {
+        let mut c = TestResultCollector::new();
+        c.add(
+            "t1".to_string(),
+            vec![passing_assert("a"), failing_assert("b")],
+            std::time::Duration::ZERO,
+        );
+        let text = c.to_text();
+        assert!(text.contains("Results:"));
+        assert!(text.contains("1 passed"));
+        assert!(text.contains("1 failed"));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -85,6 +85,9 @@ pub enum Error {
     #[error("ParseIntError {0}")]
     ParseInt(#[from] std::num::ParseIntError),
 
+    #[error("Tests failed: {0} failed out of {1} assertions")]
+    TestFailure(usize, usize),
+
     /*
         #[error("Ed25519 encode public key error {0}")]
         Ed25519EncodePublicError(#[from] ed25519_dalek::pkcs8::spki::Error),


### PR DESCRIPTION
Fixes #230

## Summary

Fixes three gaps where the linter/test-runner validated packages silently even when they contained runtime-breaking patterns.

### #4 — \`agent package test\` always returned exit 0 on assertion failures

\`test::run()\` printed \`Results: N passed, M failed, T total\` but always returned \`Ok(())\`, making CI pipelines show green even with failing assertions.

**Fix:** add a \`TestFailure(usize, usize)\` error variant and return it when \`!results.all_passed()\`. The \`process::exit(3)\` path in \`package::mod\` now fires correctly.

### #1 — \`type: object\` option with \`properties.*.default\` silently accepted

The option merge engine only supports a flat \`default:\` map at the option root. The JSON Schema nested style (\`properties: { key: { type: string, default: value } }\`) is parsed without error but the defaults are **never applied at runtime**, causing strict-mode template failures.

**Fix:** \`check_options\` now emits a \`package/object-properties-unsupported\` Warn finding when \`type == "object"\` and \`properties\` is present.

### #3 — \`context.namespace\` / \`context.tenant\` in \`type: system\` packages

\`context.namespace\` is \`()\` for system packages; accessing \`.ha\` on it throws \`Unknown property 'ha' on type '()'\`. The existing \`check_wrong_package_type\` only checked for a standalone \`tenant\` variable.

**Fix:** extend the walk to detect \`context.namespace\` and \`context.tenant\` dot-accesses. Key discovery: Rhai 1.25 compiles \`context.namespace.ha\` **right-associatively** as \`Dot(Variable("context"), Dot(Property("namespace"), Property("ha")))\`, not left-to-right. Added \`first_property_in_dot_chain()\` helper to extract the leftmost property name regardless of chain depth.

## Test plan

- [ ] All existing tests pass (\`cargo test\`)
- [ ] \`cargo clippy -- -D warnings\` clean
- [ ] \`cargo +nightly fmt --check\` clean
- [ ] New tests added for each fix (TDD — tests written before implementation):
  - \`testing::result::tests::all_passed_*\` / \`total_failed_*\` / \`to_text_*\`
  - \`package::lint::tests::check_options_object_with_nested_properties_warns\`
  - \`package::lint::tests::check_options_object_with_flat_default_passes\`
  - \`linting::rhai_checker::tests::context_namespace_access_in_system_package_warns\`
  - \`linting::rhai_checker::tests::context_tenant_access_in_system_package_warns\`
  - \`linting::rhai_checker::tests::context_cluster_access_in_system_package_no_warn\`

Issue #2 (Handlebars partial variable cross-check) is out of scope for this PR — it requires tracking which params each Rhai caller passes to each partial and is a larger refactor.